### PR TITLE
Add automation for Pages deployment and trailing-90 tooling

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,19 @@
+name: Deploy Pages
+on:
+  push:
+    branches: [ "main" ]
+    paths: [ "docs/**" ]
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+      - uses: actions/deploy-pages@v4

--- a/.github/workflows/slack-tier.yml
+++ b/.github/workflows/slack-tier.yml
@@ -1,0 +1,20 @@
+name: Twilio Tier Notifier
+on:
+  schedule: [{ cron: "0 13 * * *" }]  # 13:00 UTC daily
+  workflow_dispatch:
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Post tier to Slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          sudo apt-get update -y && sudo apt-get install -y jq bc || true
+          T90=$(cat invoices/trailing_90_usd.txt 2>/dev/null || echo "0.00")
+          tier="A"; if (( $(echo "$T90 > 250000" | bc -l) )); then tier="B"; fi
+          if (( $(echo "$T90 > 1000000" | bc -l) )); then tier="C"; fi
+          payload=$(jq -n --arg t90 "$T90" --arg tier "$tier" \
+            '{text: ("Twilio trailing-90: $" + $t90 + " → active tier: " + $tier)}')
+          curl -s -X POST -H 'Content-type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL"

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /

--- a/invoice_rollup.py
+++ b/invoice_rollup.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+import pandas as pd
+from pathlib import Path
+
+SRC = Path("invoices/csv")
+OUT = Path("invoices")
+OUT.mkdir(parents=True, exist_ok=True)
+
+frames = []
+for p in SRC.glob("*.csv"):
+    try:
+        df = pd.read_csv(p)
+        if {"date","amount_usd"} <= set(df.columns):
+            df["date"] = pd.to_datetime(df["date"])
+            frames.append(df[["date","amount_usd"]])
+    except Exception:
+        pass
+
+if frames:
+    all_df = pd.concat(frames, ignore_index=True)
+    last = all_df["date"].max()
+    trailing = all_df[ all_df["date"] >= (last - pd.Timedelta(days=90)) ]["amount_usd"].sum()
+else:
+    trailing = 0.0
+
+(Path("invoices/trailing_90_usd.txt")).write_text(str(round(float(trailing),2)))
+print("trailing_90_usd.txt written:", round(float(trailing),2))


### PR DESCRIPTION
## Summary
- add a GitHub Pages workflow that deploys the `docs` folder on updates
- add a scheduled Slack notifier workflow for trailing-90 tier updates
- add the invoice rollup utility plus supporting GitHub Pages helper files

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cabef4b5b0832892764032ed2488c0